### PR TITLE
🧹 Remove unused React import from ContentSubmission

### DIFF
--- a/frontend/src/components/ContentSubmission.tsx
+++ b/frontend/src/components/ContentSubmission.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import './ContentSubmission.css';
 import { analyzeContent } from '../services/api';
 
@@ -17,7 +17,7 @@ interface ContentSubmissionProps {
   onAnalysisComplete: (data: any) => void;
 }
 
-const ContentSubmission: React.FC<ContentSubmissionProps> = ({ onAnalysisStart, onAnalysisComplete }) => {
+const ContentSubmission = ({ onAnalysisStart, onAnalysisComplete }: ContentSubmissionProps) => {
   const [contentType, setContentType] = useState<string | null>(null);
   const [content, setContent] = useState<string>('');
   const [error, setError] = useState<string>('');


### PR DESCRIPTION
Removed unused React import and refactored component definition to not use React.FC. This improves code health by removing unnecessary dependencies and following modern React patterns.

Verified with:
- `npm run lint` (frontend)
- `npm run build` (frontend)
- Manual verification script with Playwright to ensure component rendering is intact.

---
*PR created automatically by Jules for task [9018235160563904296](https://jules.google.com/task/9018235160563904296) started by @rshermans*