### PR TITLE
🧹 Refactor API service to use centralized post helper

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import './App.css';
+import type { AnalysisResult } from './components/Results';
 import ContentSubmission from './components/ContentSubmission';
 import ContentAnalysis from './components/ContentAnalysis';
 import Results from './components/Results';
@@ -9,9 +10,9 @@ type AppState = 'submission' | 'analyzing' | 'results';
 
 function App() {
   const [appState, setAppState] = useState<AppState>('submission');
-  const [analysisResult, setAnalysisResult] = useState(null);
+  const [analysisResult, setAnalysisResult] = useState<AnalysisResult | null>(null);
 
-  const handleAnalysisComplete = (result: any) => {
+  const handleAnalysisComplete = (result: AnalysisResult) => {
     setAnalysisResult(result);
     setAppState('results');
   };

--- a/frontend/src/components/ContentSubmission.tsx
+++ b/frontend/src/components/ContentSubmission.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import './ContentSubmission.css';
 import { analyzeContent } from '../services/api';
+import type { AnalysisResult } from './Results';
 
 /**
  * Componente de submissão inicial.
@@ -14,7 +15,7 @@ export interface ContentData {
 
 interface ContentSubmissionProps {
   onAnalysisStart: () => void;
-  onAnalysisComplete: (data: any) => void;
+  onAnalysisComplete: (data: AnalysisResult) => void;
 }
 
 const ContentSubmission: React.FC<ContentSubmissionProps> = ({ onAnalysisStart, onAnalysisComplete }) => {
@@ -48,6 +49,7 @@ const ContentSubmission: React.FC<ContentSubmissionProps> = ({ onAnalysisStart, 
       const result = await analyzeContent(contentType, content);
       onAnalysisComplete(result);
     } catch (err) {
+      console.error('Error during analysis:', err);
       setError('Ocorreu um erro ao analisar o conteúdo. Tente novamente.');
       // Optional: switch back to submission form on error
       // onNewAnalysis();

--- a/frontend/src/components/Results.tsx
+++ b/frontend/src/components/Results.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import './Results.css';
 
 // Define the expected structure of the analysis result
-interface AnalysisResult {
+export interface AnalysisResult {
   analysis: string;
   sourceReliability: number;
   factualConsistency: number;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import type { AnalysisResult } from '../components/Results';
 
 /*
  * Serviço API para comunicar com o backend TrueCheck.
@@ -6,33 +7,43 @@ import axios from 'axios';
  */
 const API_URL: string = import.meta.env.VITE_API_URL || 'http://localhost:5000/api';
 
-export async function analyzeContent(contentType: string, content: string): Promise<any> {
-  const response = await axios.post(`${API_URL}/analysis/preliminary`, {
+/**
+ * Helper genérico para requisições POST.
+ * Centraliza a construção da URL, logging de erros e extração de dados do axios.
+ */
+async function post<T>(endpoint: string, data: Record<string, unknown>): Promise<T> {
+  try {
+    const response = await axios.post<T>(`${API_URL}${endpoint}`, data);
+    return response.data;
+  } catch (error) {
+    console.error(`Erro na requisição POST para ${endpoint}:`, error);
+    throw error;
+  }
+}
+
+export async function analyzeContent(contentType: string, content: string): Promise<AnalysisResult> {
+  return post<AnalysisResult>('/analysis/preliminary', {
     type: contentType,
     content: content,
   });
-  return response.data;
 }
 
-export async function crossVerifyContent(content: string, analysis: any): Promise<any> {
-  const response = await axios.post(`${API_URL}/analysis/cross-verification`, {
+export async function crossVerifyContent(content: string, analysis: unknown): Promise<unknown> {
+  return post<unknown>('/analysis/cross-verification', {
     content: content,
     analysis: analysis,
   });
-  return response.data;
 }
 
-export async function analyzeContext(content: string): Promise<any> {
-  const response = await axios.post(`${API_URL}/analysis/context`, { content });
-  return response.data;
+export async function analyzeContext(content: string): Promise<unknown> {
+  return post<unknown>('/analysis/context', { content });
 }
 
-export async function getFinalEvaluation(userPerception: any, aiAnalysis: any): Promise<any> {
-  const response = await axios.post(`${API_URL}/analysis/final`, {
+export async function getFinalEvaluation(userPerception: unknown, aiAnalysis: unknown): Promise<unknown> {
+  return post<unknown>('/analysis/final', {
     user_perception: userPerception,
     ai_analysis: aiAnalysis,
   });
-  return response.data;
 }
 
 const api = {


### PR DESCRIPTION
This PR improves the code health of the frontend API service by extracting a common POST request helper, which reduces duplication and centralizes error handling. Additionally, it enhances the overall type safety of the application by introducing proper TypeScript interfaces and removing `any` types where possible, ensuring a cleaner and more maintainable codebase.

🎯 **What:** The code health issue addressed was duplicated Axios calls in `api.ts`.
💡 **Why:** This improves maintainability by reducing boilerplate and centralizing API request logic.
✅ **Verification:** Changes were confirmed by running `npm run lint` and `npm run build` in the `frontend` directory, and by using a Playwright script to verify the application still loads correctly.
✨ **Result:** A more robust, type-safe, and DRY API service.

---
*PR created automatically by Jules for task [15994518327441589659](https://jules.google.com/task/15994518327441589659) started by @rshermans*