### PR TITLE
🧹 Improve API Service Typing with proper Interfaces

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,15 +3,16 @@ import './App.css';
 import ContentSubmission from './components/ContentSubmission';
 import ContentAnalysis from './components/ContentAnalysis';
 import Results from './components/Results';
+import type { AnalysisResult } from './types/api';
 
 // Define the possible states of the application
 type AppState = 'submission' | 'analyzing' | 'results';
 
 function App() {
   const [appState, setAppState] = useState<AppState>('submission');
-  const [analysisResult, setAnalysisResult] = useState(null);
+  const [analysisResult, setAnalysisResult] = useState<AnalysisResult | null>(null);
 
-  const handleAnalysisComplete = (result: any) => {
+  const handleAnalysisComplete = (result: AnalysisResult) => {
     setAnalysisResult(result);
     setAppState('results');
   };

--- a/frontend/src/components/ContentSubmission.tsx
+++ b/frontend/src/components/ContentSubmission.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import './ContentSubmission.css';
 import { analyzeContent } from '../services/api';
+import type { AnalysisResult } from '../types/api';
 
 /**
  * Componente de submissão inicial.
@@ -14,7 +15,7 @@ export interface ContentData {
 
 interface ContentSubmissionProps {
   onAnalysisStart: () => void;
-  onAnalysisComplete: (data: any) => void;
+  onAnalysisComplete: (data: AnalysisResult) => void;
 }
 
 const ContentSubmission: React.FC<ContentSubmissionProps> = ({ onAnalysisStart, onAnalysisComplete }) => {
@@ -47,7 +48,7 @@ const ContentSubmission: React.FC<ContentSubmissionProps> = ({ onAnalysisStart, 
     try {
       const result = await analyzeContent(contentType, content);
       onAnalysisComplete(result);
-    } catch (err) {
+    } catch {
       setError('Ocorreu um erro ao analisar o conteúdo. Tente novamente.');
       // Optional: switch back to submission form on error
       // onNewAnalysis();

--- a/frontend/src/components/Results.tsx
+++ b/frontend/src/components/Results.tsx
@@ -1,14 +1,6 @@
 import React from 'react';
 import './Results.css';
-
-// Define the expected structure of the analysis result
-interface AnalysisResult {
-  analysis: string;
-  sourceReliability: number;
-  factualConsistency: number;
-  contentQuality: number;
-  technicalIntegrity: number;
-}
+import type { AnalysisResult } from '../types/api';
 
 interface ResultsProps {
   result: AnalysisResult;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,11 @@
 import axios from 'axios';
+import type {
+  AnalysisResult,
+  CrossVerificationResult,
+  ContextAnalysisResult,
+  FinalEvaluationResult,
+  ScoreData,
+} from '../types/api';
 
 /*
  * Serviço API para comunicar com o backend TrueCheck.
@@ -6,7 +13,7 @@ import axios from 'axios';
  */
 const API_URL: string = import.meta.env.VITE_API_URL || 'http://localhost:5000/api';
 
-export async function analyzeContent(contentType: string, content: string): Promise<any> {
+export async function analyzeContent(contentType: string, content: string): Promise<AnalysisResult> {
   const response = await axios.post(`${API_URL}/analysis/preliminary`, {
     type: contentType,
     content: content,
@@ -14,7 +21,10 @@ export async function analyzeContent(contentType: string, content: string): Prom
   return response.data;
 }
 
-export async function crossVerifyContent(content: string, analysis: any): Promise<any> {
+export async function crossVerifyContent(
+  content: string,
+  analysis: AnalysisResult
+): Promise<CrossVerificationResult> {
   const response = await axios.post(`${API_URL}/analysis/cross-verification`, {
     content: content,
     analysis: analysis,
@@ -22,12 +32,15 @@ export async function crossVerifyContent(content: string, analysis: any): Promis
   return response.data;
 }
 
-export async function analyzeContext(content: string): Promise<any> {
+export async function analyzeContext(content: string): Promise<ContextAnalysisResult> {
   const response = await axios.post(`${API_URL}/analysis/context`, { content });
   return response.data;
 }
 
-export async function getFinalEvaluation(userPerception: any, aiAnalysis: any): Promise<any> {
+export async function getFinalEvaluation(
+  userPerception: ScoreData,
+  aiAnalysis: ScoreData
+): Promise<FinalEvaluationResult> {
   const response = await axios.post(`${API_URL}/analysis/final`, {
     user_perception: userPerception,
     ai_analysis: aiAnalysis,

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,29 @@
+export interface AnalysisResult {
+  analysis: string;
+  sourceReliability: number;
+  factualConsistency: number;
+  contentQuality: number;
+  technicalIntegrity: number;
+}
+
+export interface CrossVerificationResult {
+  cross_verification_summary: string;
+  verified_sources: string[];
+  confidence_score: number;
+}
+
+export interface ContextAnalysisResult {
+  context_summary: string;
+  historical_context: string;
+  current_relevance: string;
+}
+
+export interface FinalEvaluationResult {
+  final_score: number;
+  summary: string;
+  user_vs_ai_discrepancy: number;
+}
+
+export interface ScoreData {
+  [key: string]: number;
+}


### PR DESCRIPTION
This change improves the code health of the frontend API service by replacing generic `any` types with well-defined TypeScript interfaces. 

Key changes:
- Introduced `AnalysisResult`, `CrossVerificationResult`, `ContextAnalysisResult`, `FinalEvaluationResult`, and `ScoreData` interfaces in a new `frontend/src/types/api.ts` file.
- Updated all functions in `frontend/src/services/api.ts` to use these interfaces for parameters and return types.
- Refactored frontend components (`App.tsx`, `ContentSubmission.tsx`, `Results.tsx`) to import and use these shared interfaces, ensuring type safety throughout the application.
- Adjusted imports to use `import type` as required by the project's `verbatimModuleSyntax` configuration.
- Resolved a linting error regarding an unused error variable in `ContentSubmission.tsx`.
- Ensured no build artifacts or cache files are included in the submission.

---
*PR created automatically by Jules for task [15856846046473770437](https://jules.google.com/task/15856846046473770437) started by @rshermans*