### PR TITLE
🧹 Refactor Duplicated Axios Calls and Improve Type Safety

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,15 +3,16 @@ import './App.css';
 import ContentSubmission from './components/ContentSubmission';
 import ContentAnalysis from './components/ContentAnalysis';
 import Results from './components/Results';
+import type { AnalysisResult } from './services/api';
 
 // Define the possible states of the application
 type AppState = 'submission' | 'analyzing' | 'results';
 
 function App() {
   const [appState, setAppState] = useState<AppState>('submission');
-  const [analysisResult, setAnalysisResult] = useState(null);
+  const [analysisResult, setAnalysisResult] = useState<AnalysisResult | null>(null);
 
-  const handleAnalysisComplete = (result: any) => {
+  const handleAnalysisComplete = (result: AnalysisResult) => {
     setAnalysisResult(result);
     setAppState('results');
   };

--- a/frontend/src/components/ContentSubmission.tsx
+++ b/frontend/src/components/ContentSubmission.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import './ContentSubmission.css';
-import { analyzeContent } from '../services/api';
+import { analyzeContent, type AnalysisResult } from '../services/api';
 
 /**
  * Componente de submissão inicial.
@@ -14,7 +14,7 @@ export interface ContentData {
 
 interface ContentSubmissionProps {
   onAnalysisStart: () => void;
-  onAnalysisComplete: (data: any) => void;
+  onAnalysisComplete: (data: AnalysisResult) => void;
 }
 
 const ContentSubmission: React.FC<ContentSubmissionProps> = ({ onAnalysisStart, onAnalysisComplete }) => {
@@ -47,7 +47,7 @@ const ContentSubmission: React.FC<ContentSubmissionProps> = ({ onAnalysisStart, 
     try {
       const result = await analyzeContent(contentType, content);
       onAnalysisComplete(result);
-    } catch (err) {
+    } catch {
       setError('Ocorreu um erro ao analisar o conteúdo. Tente novamente.');
       // Optional: switch back to submission form on error
       // onNewAnalysis();

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,38 +1,62 @@
 import axios from 'axios';
 
+/**
+ * Interface que representa o resultado de uma análise de conteúdo.
+ */
+export interface AnalysisResult {
+  analysis: string;
+  sourceReliability: number;
+  factualConsistency: number;
+  contentQuality: number;
+  technicalIntegrity: number;
+}
+
 /*
  * Serviço API para comunicar com o backend TrueCheck.
  * A URL base é lida de VITE_API_URL, com fallback para localhost.
  */
 const API_URL: string = import.meta.env.VITE_API_URL || 'http://localhost:5000/api';
 
-export async function analyzeContent(contentType: string, content: string): Promise<any> {
-  const response = await axios.post(`${API_URL}/analysis/preliminary`, {
+/**
+ * Helper genérico para requisições POST.
+ * Centraliza a construção da URL, tratamento de erros e tipagem.
+ */
+async function post<T>(endpoint: string, data: Record<string, unknown>): Promise<T> {
+  try {
+    const response = await axios.post<T>(`${API_URL}${endpoint}`, data);
+    return response.data;
+  } catch (error) {
+    console.error(`API Error at ${endpoint}:`, error);
+    throw error;
+  }
+}
+
+export async function analyzeContent(contentType: string, content: string): Promise<AnalysisResult> {
+  return post<AnalysisResult>('/analysis/preliminary', {
     type: contentType,
     content: content,
   });
-  return response.data;
 }
 
-export async function crossVerifyContent(content: string, analysis: any): Promise<any> {
-  const response = await axios.post(`${API_URL}/analysis/cross-verification`, {
+export async function crossVerifyContent(content: string, analysis: AnalysisResult): Promise<unknown> {
+  return post<unknown>('/analysis/cross-verification', {
     content: content,
     analysis: analysis,
   });
-  return response.data;
 }
 
-export async function analyzeContext(content: string): Promise<any> {
-  const response = await axios.post(`${API_URL}/analysis/context`, { content });
-  return response.data;
+export async function analyzeContext(content: string): Promise<unknown> {
+  return post<unknown>('/analysis/context', { content });
 }
 
-export async function getFinalEvaluation(userPerception: any, aiAnalysis: any): Promise<any> {
-  const response = await axios.post(`${API_URL}/analysis/final`, {
+export async function getFinalEvaluation(
+  userPerception: Record<string, unknown>,
+  aiAnalysis: Record<string, unknown>
+): Promise<unknown> {
+  return post<unknown>('/analysis/final', {
     user_perception: userPerception,
     ai_analysis: aiAnalysis,
   });
-  return response.data;
 }
 
 const api = {


### PR DESCRIPTION
This PR addresses the "Duplicated Axios Calls" issue in `frontend/src/services/api.ts`.

Key changes:
1. **Centralized Request Handling**: A new generic `post<T>` helper function was added to `api.ts`. It handles the `API_URL` prefix, executes `axios.post`, and provides consistent error logging.
2. **Reduced Duplication**: All four API functions (`analyzeContent`, `crossVerifyContent`, `analyzeContext`, and `getFinalEvaluation`) now utilize the `post` helper, eliminating repetitive Axios logic.
3. **Enhanced Type Safety**: 
   - Defined `AnalysisResult` interface to type the API responses.
   - Replaced `any` with specific types or `unknown` to satisfy ESLint and improve code health.
   - Updated `App.tsx` and `ContentSubmission.tsx` to align with the new types, including using type-only imports where required.
4. **Clean Lint & Build**: Fixed pre-existing lint and TypeScript errors in the affected files. The project now builds and lints cleanly.

Verification:
- Manual verification via Playwright screenshot confirmed the application remains fully functional.
- `npm run lint` and `npm run build` pass without errors.

---
*PR created automatically by Jules for task [15158830874952434827](https://jules.google.com/task/15158830874952434827) started by @rshermans*