### PR TITLE
Remove debug initial load screenshot from verification script

### DIFF
--- a/jules-scratch/verification/verify_truecheck.py
+++ b/jules-scratch/verification/verify_truecheck.py
@@ -8,9 +8,6 @@ def run_verification(page: Page):
     # 1. Navigate to the app
     page.goto("http://localhost:5173")
 
-    # DEBUG: Take a screenshot immediately to see what the page looks like on load
-    page.screenshot(path="jules-scratch/verification/debug_initial_load.png")
-
     # 2. Select input type and fill content
     page.get_by_role("button", name="Texto").click()
 


### PR DESCRIPTION
This change removes a debugging artifact from `jules-scratch/verification/verify_truecheck.py`. Specifically, it removes the call to `page.screenshot` and its associated comment that were used to debug the initial page load in the Playwright verification script.

---
*PR created automatically by Jules for task [10884849990668659358](https://jules.google.com/task/10884849990668659358) started by @rshermans*